### PR TITLE
Enhancement/member swap logic

### DIFF
--- a/src/main/java/in/handyman/raven/lib/adapters/comparison/ContainsComparisonAdapter.java
+++ b/src/main/java/in/handyman/raven/lib/adapters/comparison/ContainsComparisonAdapter.java
@@ -79,29 +79,34 @@ public class ContainsComparisonAdapter implements ComparisonAdapter{
         }
 
         if (!"multi_value".equals(controlDataInputLineItem.getLineItemType())) {
-            Set<String> actualTokens = Arrays.stream(actualData.split(","))
+            Set<String> extractedWords = Arrays.stream(normalizedExtracted.replaceAll("[^a-zA-Z0-9,]", " ")
+                            .toLowerCase()
+                            .split("\\s+"))
                     .map(String::trim)
-                    .map(String::toLowerCase)
                     .filter(s -> !s.isEmpty())
                     .collect(Collectors.toSet());
 
-            Set<String> extractedTokens = Arrays.stream(normalizedExtracted.split(","))
+            Set<String> actualWords = Arrays.stream(actualData.replaceAll("[^a-zA-Z0-9,]", " ")
+                            .toLowerCase()
+                            .split("\\s+"))
                     .map(String::trim)
-                    .map(String::toLowerCase)
                     .filter(s -> !s.isEmpty())
                     .collect(Collectors.toSet());
 
-            if (actualTokens.equals(extractedTokens)) {
+            if (actualWords.equals(extractedWords)) {
                 return 0L;  // swap-tolerant match for single_value
             }
         }
 
-        Set<String> extractedWords = Arrays.stream(normalizeExtractedData.replaceAll("[^a-zA-Z0-9,]", "").toLowerCase().split("[\\s,]+"))
+        Set<String> extractedWords = Arrays.stream(actualData.split(","))
                 .map(String::trim)
+                .map(String::toLowerCase)
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toSet());
-        Set<String> actualWords = Arrays.stream(actualData.replaceAll("[^a-zA-Z0-9,]", "").toLowerCase().split("[\\s,]+"))
+
+        Set<String> actualWords = Arrays.stream(normalizedExtracted.split(","))
                 .map(String::trim)
+                .map(String::toLowerCase)
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toSet());
         if (extractedWords.equals(actualWords)) {

--- a/src/main/java/in/handyman/raven/lib/adapters/comparison/ContainsComparisonAdapter.java
+++ b/src/main/java/in/handyman/raven/lib/adapters/comparison/ContainsComparisonAdapter.java
@@ -78,6 +78,24 @@ public class ContainsComparisonAdapter implements ComparisonAdapter{
             return 0L;
         }
 
+        if (!"multi_value".equals(controlDataInputLineItem.getLineItemType())) {
+            Set<String> actualTokens = Arrays.stream(actualData.split(","))
+                    .map(String::trim)
+                    .map(String::toLowerCase)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toSet());
+
+            Set<String> extractedTokens = Arrays.stream(normalizedExtracted.split(","))
+                    .map(String::trim)
+                    .map(String::toLowerCase)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toSet());
+
+            if (actualTokens.equals(extractedTokens)) {
+                return 0L;  // swap-tolerant match for single_value
+            }
+        }
+
         Set<String> extractedWords = Arrays.stream(normalizeExtractedData.replaceAll("[^a-zA-Z0-9,]", "").toLowerCase().split("[\\s,]+"))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())

--- a/src/test/java/in/handyman/raven/lib/ContainsComparisonAdapterTest.java
+++ b/src/test/java/in/handyman/raven/lib/ContainsComparisonAdapterTest.java
@@ -1,0 +1,92 @@
+package in.handyman.raven.lib;
+
+import in.handyman.raven.lambda.doa.audit.ActionExecutionAudit;
+import in.handyman.raven.lib.adapters.comparison.ContainsComparisonAdapter;
+import in.handyman.raven.lib.model.controldatacomaprison.ControlDataComparisonQueryInputTable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ContainsComparisonAdapterTest {
+
+    private ContainsComparisonAdapter adapter;
+    private Logger log;
+    private ActionExecutionAudit audit;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new ContainsComparisonAdapter();
+        log = LoggerFactory.getLogger(ContainsComparisonAdapterTest.class);
+        audit = new ActionExecutionAudit();
+    }
+
+    private ControlDataComparisonQueryInputTable buildInput(String actual, String extracted, String type) {
+        return ControlDataComparisonQueryInputTable.builder()
+                .actualValue(actual)
+                .extractedValue(extracted)
+                .lineItemType(type)
+                .originId("TEST_ORIGIN")
+                .paperNo(1L)
+                .sorItemName("TEST_ITEM")
+                .tenantId(99L)
+                .build();
+    }
+
+    @Test
+    void testExactMatchSameOrder() {
+        ControlDataComparisonQueryInputTable input = buildInput(
+                "Dhanekula Manohar", "Dhanekula Manohar", "multi_value"
+        );
+        Long result = adapter.dataValidation(input, log, audit);
+        assertEquals(0L, result, "Names should match exactly");
+    }
+
+    @Test
+    void testExactMatchDifferentOrder() {
+        ControlDataComparisonQueryInputTable input = buildInput(
+                "Dhanekula Manohar", "Manohar Dhanekula", "single_value"
+        );
+        Long result = adapter.dataValidation(input, log, audit);
+        assertEquals(0L, result, "Names should match even if swapped");
+    }
+
+    @Test
+    void testThreeWordsReordered() {
+        ControlDataComparisonQueryInputTable input = buildInput(
+                "Dhanekula Giri Manohar, Dhanekula Manohar", "Dhanekula Manohar, Dhanekula Giri Manohar", "multi_value"
+        );
+        Long result = adapter.dataValidation(input, log, audit);
+        assertEquals(0L, result, "Names should match when all tokens are present in different order");
+    }
+
+    @Test
+    void testPartialMismatch() {
+        ControlDataComparisonQueryInputTable input = buildInput(
+                "Manohar Dhanekula", "Manohar Giri", "multi_value"
+        );
+        Long result = adapter.dataValidation(input, log, audit);
+        // not equal sets → should return Levenshtein distance > 0
+        assertEquals(true, result > 0, "Different tokens should not match");
+    }
+
+    @Test
+    void testEmptyExtracted() {
+        ControlDataComparisonQueryInputTable input = buildInput(
+                "Some Value", "", "multi_value"
+        );
+        Long result = adapter.dataValidation(input, log, audit);
+        assertEquals(input.getActualValue().length(), result);
+    }
+
+    @Test
+    void testEmptyActual() {
+        ControlDataComparisonQueryInputTable input = buildInput(
+                "", "Some Value", "multi_value"
+        );
+        Long result = adapter.dataValidation(input, log, audit);
+        assertEquals(input.getExtractedValue().length(), result);
+    }
+}


### PR DESCRIPTION
## Fix: Allow swapped word order in `ContainsComparisonAdapter`

- Updated `dataValidation()` to treat values as a **set of words** instead of comparing full strings.  
- Ensures `"Dhanekula Manohar"` and `"Manohar Dhanekula"` are considered a match.  
- Added a unit test to confirm swapped names return `0L` (match).  
